### PR TITLE
Wagtail 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,34 +31,14 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.11']
-        django: ['3.2', '4.1']
-        wagtail: ['4.1', '4.2', '5.0', '5.1']
-        include:
-          - python: '3.8'
+        python: ['3.8', '3.9', '3.10', '3.11']
+        django: ['3.2', '4.1', '4.2']
+        wagtail: ['4.1', '5.1', '5.2']
+        exclude:
+          - django: '4.2'
+            wagtail: '4.1'
+          - python: '3.11'
             django: '3.2'
-            wagtail: '3.0'
-          - python: '3.8'
-            django: '3.2'
-            wagtail: '5.0'
-          - python: '3.8'
-            django: '4.1'
-            wagtail: '5.0'
-          - python: '3.8'
-            django: '4.2'
-            wagtail: '5.0'
-          - python: '3.11'
-            django: '4.1'
-            wagtail: '5.0'
-          - python: '3.11'
-            django: '4.2'
-            wagtail: '5.0'
-          - python: '3.11'
-            django: '4.1'
-            wagtail: '5.1'
-          - python: '3.11'
-            django: '4.2'
-            wagtail: '5.1'
 
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8}-django{3.2}-wagtail{3.0},
-    python{3.8,3.11}-django{3.2,4.1}-wagtail{4.1,4.2},
-    python{3.8,3.11}-django{3.2,4.1,4.2}-wagtail{5.0,5.1},
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,5.1,5.2}
+    python3.11-django4.1-wagtail{4.1,5.1,5.2}
+    python3.11-django4.2-wagtail{5.1,5.2}
     coverage
 
 [testenv]
@@ -14,17 +14,17 @@ commands=
 
 basepython=
     python3.8: python3.8
+    python3.9: python3.9
+    python3.10: python3.10
     python3.11: python3.11
 
 deps=
     django3.2: Django>=3.2,<3.3
     django4.1: Django>=4.1,<4.2
     django4.2: Django>=4.2,<4.3
-    wagtail3.0: wagtail>=3.0,<4.0
-    wagtail4.1: wagtail>=4.1,<4.2
-    wagtail4.2: wagtail>=4.2,<5.0
-    wagtail5.0: wagtail>=5.0,<5.1
+    wagtail4.1: wagtail>=4.1,<5.0
     wagtail5.1: wagtail>=5.1,<5.2
+    wagtail5.2: wagtail>=5.2,<5.3
 
 [testenv:lint]
 basepython=python3.8

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
 
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 
@@ -45,10 +46,13 @@ class CanViewBlockInventoryMenuItem(MenuItem):
 
 @hooks.register("register_reports_menu_item")
 def register_inventory_report_menu_item():
+    key = "classname" if WAGTAIL_VERSION >= (5, 2) else "classnames"
+    icon = "icon icon-" + BlockInventoryReportView.header_icon
+
     return CanViewBlockInventoryMenuItem(
         "Block inventory",
         reverse("wagtailinventory:block_inventory_report"),
-        classnames="icon icon-" + BlockInventoryReportView.header_icon,
+        **{key: icon},
     )
 
 


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

## Upgrade considerations

- [Adoption of classname convention for MenuItem related classes and hooks](https://docs.wagtail.org/en/stable/releases/5.2.html#adoption-of-classname-convention-for-menuitem-related-classes-and-hooks)

### Other changes

- Update test matrices
- Drop tests for Wagtail 4.2 and 5.0 as they have reached EOL